### PR TITLE
Implement previous, next, first and last frame buttons

### DIFF
--- a/app/animator.html
+++ b/app/animator.html
@@ -112,12 +112,12 @@
                     </td>
                     <td id="playback-controls">
                       <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
-                      <div id="btn-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
-                      <div id="btn-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
+                      <div id="btn-frame-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
+                      <div id="btn-frame-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
                       <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
                       <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
-                      <div id="btn-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
-                      <div id="btn-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
+                      <div id="btn-frame-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
+                      <div id="btn-frame-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
                     </td>
                 </tr>
             </table>

--- a/app/animator.html
+++ b/app/animator.html
@@ -111,7 +111,6 @@
                             </div>
                     </td>
                     <td id="playback-controls">
-                      <div id="btn-audio-toggle" title= "Toggle audio" class="active"><i class="fa fa-volume-up"></i></div>
                       <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
                       <div id="btn-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
                       <div id="btn-next" title="Next frame"><i class="fa fa-step-forward"></i></div>

--- a/app/animator.html
+++ b/app/animator.html
@@ -56,7 +56,6 @@
                 <ul id="capture-options">
                     <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#" onclick="alert('Coming soon!');">Change resolution</a></li>
                     <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#" onclick="alert('Coming soon!');">Change camera</a></li>
-                    <li><input id="audio-toggle" type="checkbox" checked><label for="audio-toggle">Play audio</label></li>
                 </ul>
             </div>
 
@@ -112,6 +111,7 @@
                             </div>
                     </td>
                     <td id="playback-controls">
+                      <div id="btn-audio-toggle" title= "Toggle audio" class="active"><i class="fa fa-volume-up"></i></div>
                       <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
                       <div id="btn-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
                       <div id="btn-next" title="Next frame"><i class="fa fa-step-forward"></i></div>

--- a/app/animator.html
+++ b/app/animator.html
@@ -112,9 +112,13 @@
                             </div>
                     </td>
                     <td id="playback-controls">
-                            <div id="btn-loop" class="mediaControls" title="Loop Playback"><i class="fa fa-refresh"></i></div>
-                            <div id="btn-stop" class="mediaControls" title="Stop Playback"><i class="fa fa-stop"></i></div>
-                            <div id="btn-play-pause" class="mediaControls" title="Playback Frames"><i class="fa fa-play"></i></div>
+                      <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
+                      <div id="btn-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
+                      <div id="btn-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
+                      <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
+                      <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
+                      <div id="btn-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
+                      <div id="btn-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
                     </td>
                 </tr>
             </table>

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -247,7 +247,7 @@ a {
 }
 
 #left-controls {
-  width: 35%;
+  width: 45%;
 }
 
 #left-controls i {
@@ -260,7 +260,7 @@ a {
 }
 
 #playback-controls {
-  width: 35%;
+  width: 45%;
   font-size: 1.2em;
 }
 
@@ -282,7 +282,7 @@ a {
   padding: 0 0.5em;
   float: right;
 }
-#btn-play-pause, #btn-audio-toggle {
+#btn-play-pause {
   width: 1.5em;
 }
 

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -282,9 +282,8 @@ a {
   padding: 0 0.5em;
   float: right;
 }
-#btn-play-pause {
+#btn-play-pause, #btn-audio-toggle {
   width: 1.5em;
-  text-align: center;
 }
 
 #btn-loop i.active, #btn-onion-skin-toggle i.active {

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -278,9 +278,13 @@ a {
   color: #f3f76e;
 }
 
-#btn-play-pause, #btn-stop, #btn-loop {
-  padding: 0 0.25em;
+#playback-controls div {
+  padding: 0 0.5em;
   float: right;
+}
+#btn-play-pause {
+  width: 1.5em;
+  text-align: center;
 }
 
 #btn-loop i.active, #btn-onion-skin-toggle i.active {

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -53,8 +53,10 @@ var width  = 640,
     inputChangeFR = document.querySelector("#input-fr-change"),
 
     // Audio
-    captureAudio = new Audio("audio/camera.wav"),
-    audioToggle  = document.querySelector("#audio-toggle"),
+    captureAudio       = new Audio("audio/camera.wav"),
+    btnAudioToggle     = document.querySelector("#btn-audio-toggle"),
+    btnAudioToggleIcon = document.querySelector("#btn-audio-toggle i"),
+
 
     // Status bar
     statusBarCurMode   = document.querySelector("#current-mode span"),
@@ -255,18 +257,20 @@ function startup() {
 
   // Preview one frame to the right on framereel
   btnNext.addEventListener("click", function() {
-    if (curSelectedFrame !== totalFrames && winMode === "playback") {
-      videoJumpTo(curSelectedFrame + 1);
-    } else {
-      btnLiveView.click();
+    if (curSelectedFrame) {
+      if (curSelectedFrame !== totalFrames) {
+        videoJumpTo(curSelectedFrame + 1);
+      } else {
+        btnLiveView.click();
+      }
     }
   });
 
   // Preview one frame to the left on framereel
   btnPrevious.addEventListener("click", function() {
-    if (curSelectedFrame > 1 && winMode === "playback") {
-      videoJumpTo(curSelectedFrame - 1);
-    } else if (winMode === "capture") {
+    if (curSelectedFrame > 1) {
+        videoJumpTo(curSelectedFrame - 1);
+    } else  if (winMode === "capture") {
       switchMode("playback");
       videoJumpTo(totalFrames);
     }
@@ -282,10 +286,25 @@ function startup() {
 
   // Preview last frame on framereel
   btnLast.addEventListener("click", function() {
-    if (curSelectedFrame < totalFrames && winMode === "playback") {
-      videoStop();
+    if (curSelectedFrame) {
+      if (curSelectedFrame !== totalFrames) {
+        videoStop();
+      } else {
+        btnLiveView.click();
+      }
+    }
+  });
+
+  // Audio toggle change
+  btnAudioToggle.addEventListener("click", function() {
+    if (btnAudioToggle.classList.contains("active")) {
+      btnAudioToggle.classList.remove("active");
+      btnAudioToggleIcon.classList.remove("fa-volume-up");
+      btnAudioToggleIcon.classList.add("fa-volume-off");
     } else {
-      btnLiveView.click();
+      btnAudioToggle.classList.add("active");
+      btnAudioToggleIcon.classList.remove("fa-volume-off");
+      btnAudioToggleIcon.classList.add("fa-volume-up");
     }
   });
 
@@ -313,12 +332,14 @@ function startup() {
         notifyInfo("That feature is not yet implemented.");
     });
 
-    // Switch from frame preview back to live view
-    btnLiveView.addEventListener("click", function() {
-        videoStop();
-        _removeFrameReelSelection();
-        switchMode("capture");
-    });
+  // Switch from frame preview back to live view
+  btnLiveView.addEventListener("click", function() {
+    if (totalFrames > 0) {
+      videoStop();
+      _removeFrameReelSelection();
+      switchMode("capture");
+    }
+  });
 
     // Preview a captured frame
     frameReelRow.addEventListener("click", function(e) {
@@ -522,7 +543,7 @@ function _toggleOnionSkin(ev) {
  */
 function audio(name) {
     "use strict";
-    if (audioToggle.checked) {
+    if (btnAudioToggle.classList.contains("active")) {
         name.play();
     }
 }
@@ -624,6 +645,7 @@ function videoJumpTo(id) {
     curPlayFrame = id - 1;
     playback.setAttribute("src", capturedFrames[id - 1]);
     _updateStatusBarCurFrame(id);
+    _frameReelScroll();
   }
 }
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -37,19 +37,19 @@ var width  = 640,
     btnDeleteLastFrame = document.querySelector("#btn-delete-last-frame"),
 
     // Playback
-    frameRate     = 15,
-    isPlaying     = false,
-    isLooping     = false,
-    curPlayFrame  = 0,
-    playBackLoop  = null,
-    btnStop       = document.querySelector("#btn-stop"),
-    btnLoop       = document.querySelector("#btn-loop"),
-    playback      = document.querySelector("#playback"),
-    btnPlayPause  = document.querySelector("#btn-play-pause"),
-    btnNext       = document.querySelector("#btn-next"),
-    btnPrevious   = document.querySelector("#btn-previous"),
-    btnFirst      = document.querySelector("#btn-first"),
-    btnLast       = document.querySelector("#btn-last"),
+    frameRate        = 15,
+    isPlaying        = false,
+    isLooping        = false,
+    curPlayFrame     = 0,
+    playBackLoop     = null,
+    btnStop          = document.querySelector("#btn-stop"),
+    btnLoop          = document.querySelector("#btn-loop"),
+    playback         = document.querySelector("#playback"),
+    btnPlayPause     = document.querySelector("#btn-play-pause"),
+    btnFrameNext     = document.querySelector("#btn-frame-next"),
+    btnFramePrevious = document.querySelector("#btn-frame-previous"),
+    btnFrameFirst    = document.querySelector("#btn-frame-first"),
+    btnFrameLast     = document.querySelector("#btn-frame-last"),
     inputChangeFR = document.querySelector("#input-fr-change"),
 
     // Audio
@@ -254,10 +254,10 @@ function startup() {
     });
 
   // Preview one frame to the right on framereel
-  btnNext.addEventListener("click", function() {
+  btnFrameNext.addEventListener("click", function() {
     if (curSelectedFrame) {
       if (curSelectedFrame !== totalFrames) {
-        videoJumpTo(curSelectedFrame + 1);
+        _displayFrame(curSelectedFrame + 1);
       } else {
         btnLiveView.click();
       }
@@ -265,25 +265,25 @@ function startup() {
   });
 
   // Preview one frame to the left on framereel
-  btnPrevious.addEventListener("click", function() {
+  btnFramePrevious.addEventListener("click", function() {
     if (curSelectedFrame > 1) {
-        videoJumpTo(curSelectedFrame - 1);
-    } else  if (winMode === "capture") {
+        _displayFrame(curSelectedFrame - 1);
+    } else if (winMode === "capture") {
       switchMode("playback");
-      videoJumpTo(totalFrames);
+      _displayFrame(totalFrames);
     }
   });
 
   // Preview first frame on framereel
-  btnFirst.addEventListener("click", function() {
+  btnFrameFirst.addEventListener("click", function() {
     if (winMode === "capture") {
       switchMode("playback");
     }
-    videoJumpTo(1);
+    _displayFrame(1);
   });
 
   // Preview last frame on framereel
-  btnLast.addEventListener("click", function() {
+  btnFrameLast.addEventListener("click", function() {
     if (curSelectedFrame) {
       if (curSelectedFrame !== totalFrames) {
         videoStop();
@@ -528,7 +528,7 @@ function _toggleOnionSkin(ev) {
  */
 function audio(name) {
     "use strict";
-    if (playAudio === true) {
+    if (playAudio) {
         name.play();
     }
 }
@@ -608,7 +608,7 @@ function videoPause() {
  */
 function videoStop() {
   "use strict";
-  videoJumpTo(totalFrames);
+  _displayFrame(totalFrames);
   curPlayFrame = 0;
   console.info("Playback stopped");
 }
@@ -618,7 +618,7 @@ function videoStop() {
  *
  * @param {Integer} id The frame ID to preview.
  */
-function videoJumpTo(id) {
+function _displayFrame(id) {
   "use strict";
   if (totalFrames > 0) {
     // Reset the player
@@ -681,6 +681,7 @@ function previewCapturedFrames() {
     // Begin playing the frames
     isPlaying = true;
     playBackLoop = setInterval(_videoPlay, (1000 / frameRate));
+    console.info("Playback started");
 }
 
 /**

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -53,10 +53,8 @@ var width  = 640,
     inputChangeFR = document.querySelector("#input-fr-change"),
 
     // Audio
-    captureAudio       = new Audio("audio/camera.wav"),
-    btnAudioToggle     = document.querySelector("#btn-audio-toggle"),
-    btnAudioToggleIcon = document.querySelector("#btn-audio-toggle i"),
-
+    captureAudio = new Audio("audio/camera.wav"),
+    playAudio    = true,
 
     // Status bar
     statusBarCurMode   = document.querySelector("#current-mode span"),
@@ -295,19 +293,6 @@ function startup() {
     }
   });
 
-  // Audio toggle change
-  btnAudioToggle.addEventListener("click", function() {
-    if (btnAudioToggle.classList.contains("active")) {
-      btnAudioToggle.classList.remove("active");
-      btnAudioToggleIcon.classList.remove("fa-volume-up");
-      btnAudioToggleIcon.classList.add("fa-volume-off");
-    } else {
-      btnAudioToggle.classList.add("active");
-      btnAudioToggleIcon.classList.remove("fa-volume-off");
-      btnAudioToggleIcon.classList.add("fa-volume-up");
-    }
-  });
-
     // Listen for frame rate changes
     inputChangeFR.addEventListener("input", function() {
         if (inputChangeFR.value >= 1 && inputChangeFR.value <= 60) {
@@ -543,7 +528,7 @@ function _toggleOnionSkin(ev) {
  */
 function audio(name) {
     "use strict";
-    if (btnAudioToggle.classList.contains("active")) {
+    if (playAudio === true) {
         name.play();
     }
 }
@@ -696,7 +681,6 @@ function previewCapturedFrames() {
     // Begin playing the frames
     isPlaying = true;
     playBackLoop = setInterval(_videoPlay, (1000 / frameRate));
-    console.info("Playback started");
 }
 
 /**
@@ -1038,6 +1022,20 @@ function loadMenu() {
       key: "1",
       modifiers: "ctrl",
     }));
+
+  captureMenu.append(new nw.MenuItem({ type: "separator" }));
+
+  captureMenu.append(new nw.MenuItem({
+    label: "Play capture sounds",
+    click: function() {
+      playAudio = !playAudio;
+      notifyInfo(`Capture sounds ${playAudio ? "enabled" : "disabled"}`);
+    },
+    type: "checkbox",
+    checked: true,
+    key: "m",
+    modifiers: "ctrl",
+  }));
 
     // Help menu items
     helpMenu.append(new nw.MenuItem({

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -46,6 +46,10 @@ var width  = 640,
     btnLoop       = document.querySelector("#btn-loop"),
     playback      = document.querySelector("#playback"),
     btnPlayPause  = document.querySelector("#btn-play-pause"),
+    btnNext       = document.querySelector("#btn-next"),
+    btnPrevious   = document.querySelector("#btn-previous"),
+    btnFirst      = document.querySelector("#btn-first"),
+    btnLast       = document.querySelector("#btn-last"),
     inputChangeFR = document.querySelector("#input-fr-change"),
 
     // Audio
@@ -245,11 +249,39 @@ function startup() {
     // Stop the preview
     btnStop.addEventListener("click", function() {
         if (totalFrames > 0 && winMode === "playback") {
-            _removeFrameReelSelection();
-            _addFrameReelSelection(totalFrames);
             videoStop();
         }
     });
+
+  // Preview one frame to the right on framereel
+  btnNext.addEventListener("click", function() {
+    if (curSelectedFrame !== totalFrames) {
+      videoJumpTo(curSelectedFrame + 1);
+    } else {
+      btnLiveView.click();
+    }
+  });
+
+  // Preview one frame to the left on framereel
+  btnPrevious.addEventListener("click", function() {
+    if (curSelectedFrame > 1 && winMode === "playback") {
+      videoJumpTo(curSelectedFrame - 1);
+    } else if (winMode === "capture") {
+      switchMode("playback");
+      videoJumpTo(totalFrames);
+    }
+  });
+
+  // Preview first frame on framereel
+  btnFirst.addEventListener("click", function() {
+    if (winMode === "capture") {
+      switchMode("playback");
+    }
+    videoJumpTo(1);
+  });
+
+  // Preview last frame on framereel
+  btnLast.addEventListener("click", videoStop);
 
     // Listen for frame rate changes
     inputChangeFR.addEventListener("input", function() {
@@ -563,15 +595,37 @@ function videoPause() {
  * Fully stop captured frames preview video.
  */
 function videoStop() {
-    "use strict";
+  "use strict";
+  // Reset the player
+  videoPause();
+  _removeFrameReelSelection();
+  _addFrameReelSelection(totalFrames);
+  curPlayFrame = 0;
+  playback.setAttribute("src", capturedFrames[totalFrames - 1]);
+
+  // Display newest frame number in status bar
+  _updateStatusBarCurFrame(totalFrames);
+  console.info("Playback stopped");
+}
+
+/**
+ * Pause playback and view a specific frame in the preview area.
+ *
+ * @param {Integer} id The frame ID to preview.
+ */
+function videoJumpTo(id) {
+  "use strict";
+  if (totalFrames > 0) {
     // Reset the player
     videoPause();
-    curPlayFrame = 0;
-    playback.setAttribute("src", capturedFrames[totalFrames - 1]);
+    _removeFrameReelSelection();
+    _addFrameReelSelection(id);
+    curPlayFrame = id - 1;
+    playback.setAttribute("src", capturedFrames[id - 1]);
 
     // Display newest frame number in status bar
-    _updateStatusBarCurFrame(totalFrames);
-    console.info("Playback stopped");
+    _updateStatusBarCurFrame(id);
+  }
 }
 
 /**

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -248,14 +248,14 @@ function startup() {
 
     // Stop the preview
     btnStop.addEventListener("click", function() {
-        if (totalFrames > 0 && winMode === "playback") {
+        if (winMode === "playback") {
             videoStop();
         }
     });
 
   // Preview one frame to the right on framereel
   btnNext.addEventListener("click", function() {
-    if (curSelectedFrame !== totalFrames) {
+    if (curSelectedFrame !== totalFrames && winMode === "playback") {
       videoJumpTo(curSelectedFrame + 1);
     } else {
       btnLiveView.click();
@@ -281,7 +281,13 @@ function startup() {
   });
 
   // Preview last frame on framereel
-  btnLast.addEventListener("click", videoStop);
+  btnLast.addEventListener("click", function() {
+    if (curSelectedFrame < totalFrames && winMode === "playback") {
+      videoStop();
+    } else {
+      btnLiveView.click();
+    }
+  });
 
     // Listen for frame rate changes
     inputChangeFR.addEventListener("input", function() {
@@ -596,15 +602,8 @@ function videoPause() {
  */
 function videoStop() {
   "use strict";
-  // Reset the player
-  videoPause();
-  _removeFrameReelSelection();
-  _addFrameReelSelection(totalFrames);
+  videoJumpTo(totalFrames);
   curPlayFrame = 0;
-  playback.setAttribute("src", capturedFrames[totalFrames - 1]);
-
-  // Display newest frame number in status bar
-  _updateStatusBarCurFrame(totalFrames);
   console.info("Playback stopped");
 }
 
@@ -619,11 +618,11 @@ function videoJumpTo(id) {
     // Reset the player
     videoPause();
     _removeFrameReelSelection();
+
+    // Preview selected frame ID
     _addFrameReelSelection(id);
     curPlayFrame = id - 1;
     playback.setAttribute("src", capturedFrames[id - 1]);
-
-    // Display newest frame number in status bar
     _updateStatusBarCurFrame(id);
   }
 }


### PR DESCRIPTION
This PR fixes #141 by implementing previous, next, first and last frame buttons. In addition it moves the audio toggle from the sidebar to the playback controls area:

<img width="289" alt="issue-141" src="https://cloud.githubusercontent.com/assets/8095888/14937557/b56e0baa-0f02-11e6-93c5-5b286c32acb4.PNG">

From the picture above you can see that this does make the playback controls area a bit cluttered. As a result, when #155 is implemented, I think it would be good if the "next" and "previous" buttons were removed and their functionality be made available purely via keyboard shortcuts.

Playback controls area without previous and next buttons:
<img width="219" alt="issue-141-2" src="https://cloud.githubusercontent.com/assets/8095888/14937576/3c84b83c-0f03-11e6-9dc8-0b64fb9732d8.PNG">
 