### PR TITLE
Fix playback scroll

### DIFF
--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -336,9 +336,12 @@ a {
 #area-frame-reel > table.hidden { display: none; }
 
 /* Image container */
+td:first-of-type .frame-reel-preview {
+  padding-left: 0.25em;
+}
 .frame-reel-preview {
   position: relative;
-  padding-left: 0.25em;
+  padding-right: 0.25em;
 }
 
 /* Preview image */

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -362,7 +362,6 @@ td:first-of-type .frame-reel-preview {
   text-align: center;
   font-size: 2.5em;
   cursor: pointer;
-  margin-right: 5px;
 }
 #btn-live-view:hover { color: #ad0000; }
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -712,7 +712,7 @@ function _frameReelScroll() {
         frameReelArea.scrollLeft = 0;
     } else if (curPlayFrame + 1 !== totalFrames) {
         // Scroll so currently played frame is in view
-        document.querySelector(`.frame-reel-img#img-${curPlayFrame + 1}`).scrollIntoView();
+        document.querySelector(`.frame-reel-img#img-${curPlayFrame + 1}`).parentNode.scrollIntoView();
     } else {
         // Scroll to end when playback has stopped
         frameReelArea.scrollLeft = frameReelArea.scrollWidth;


### PR DESCRIPTION
Currently when playback occurs and the frame reel has to scroll, the right side of the current selected frame's thumbnail is cut off.

This PR provides a small fix to this.