### PR TITLE
Add live reloading function to utils.js #199

### DIFF
--- a/app/about.html
+++ b/app/about.html
@@ -27,6 +27,7 @@
         </ul>
     </div>
 
+    <script id="dev-reload-script"></script>
     <script src="js/utils.js"></script>
     <script src="js/about.js" async></script>
 </body>

--- a/app/animator.html
+++ b/app/animator.html
@@ -152,6 +152,7 @@
         </ul>
     </div>
 
+  <script id="dev-reload-script"></script>
   <script src="js/utils.js"></script>
   <script src="js/main.js"></script>
 </body>

--- a/app/index.html
+++ b/app/index.html
@@ -49,6 +49,7 @@
         </ul>
     </div>
 
+    <script id="dev-reload-script"></script>
     <script src="js/utils.js"></script>
     <script src="js/index.js"></script>
 </body>

--- a/app/js/utils.js
+++ b/app/js/utils.js
@@ -1,5 +1,13 @@
 const utils = (function() {
   "use strict";
+  let devLiveReloadScript = document.querySelector("#dev-reload-script"),
+      liveReload          = false;
+
+  // Get live reload setting from current session
+  if (sessionStorage.getItem("ba-dev-live-reload")) {
+    liveReload = (sessionStorage.getItem("ba-dev-live-reload") === "true");
+    setLiveReload(liveReload);
+  }
 
   /**
    * Open a URL in the user's browser.
@@ -10,7 +18,21 @@ const utils = (function() {
     nw.Shell.openExternal(url);
   }
 
+  /**
+   * Sets whether to live reload or not (for development purposes).
+   * 
+   * @param {boolean} reload - Set to true to enable live reloading.
+   */
+  function setLiveReload(reload) {
+    // Update script tag src
+    devLiveReloadScript.src = (reload ? "../node_modules/nw-dev/lib/dev.js" : "");
+
+    // Update session storage item
+    sessionStorage.setItem("ba-dev-live-reload", reload);
+  }
+
   return {
-    openURL: openURL
+    openURL: openURL,
+    setLiveReload: setLiveReload
   };
 }());

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
         "command-line-args": "^3.0.0",
         "mkdirp": "^0.5.1"
     },
+    "devDependencies": {
+        "nw-dev": "^3.0.1"
+    },
     "scripts": {
         "postinstall": "node install",
         "start": "nwb nwbuild -v 0.19.3-sdk -r .",


### PR DESCRIPTION
This add a live reloading function (issue #199) to utils.js for development purposes. To activate live reloading `utils.setLiveReload(true)` should be typed into the devtools console. This choice is then remembered for the remainder of the current session.

I initially wanted to do perform a check for a SDK build of NW.js and have a toggle for this feature in the GUI under a Developer menu, however I was unable to find an easy way of doing so. I still think this feature is very useful in console only form though and I'd like to see this implemented asap.