### PR TITLE
Remove unnecessary CSS and convert elements to use Flexbox

### DIFF
--- a/app/about.html
+++ b/app/about.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2">
@@ -35,4 +36,5 @@
   <script src="js/utils.js"></script>
   <script src="js/about.js" async></script>
 </body>
+
 </html>

--- a/app/about.html
+++ b/app/about.html
@@ -16,9 +16,11 @@
       <h1>Boats Animator</h1>
       <h2 id="app-version">Version</h2>
       <p>Boats Animator is a free cross-platform stop motion animation program created using HTML5, JavaScript, and WebRTC. Want to help out? <a href="#" onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/issues')">Report any issues</a> you come across or <a href="#" onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/blob/master/CONTRIBUTING.md')">contribute code</a>!</p>
-      <button onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/blob/master/LICENSE')"><i class="fa fa-legal"></i><span>License</span></button>
-      <button onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/graphs/contributors')"><i class="fa fa-list-ul"></i><span>Credits</span></button>
-      <button onclick="utils.openURL('http://charlielee.uk/animator')"><i class="fa fa-tv"></i><span>Website</span></button>
+      <div class="btn-group">
+        <button onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/blob/master/LICENSE')"><i class="fa fa-legal"></i><span>License</span></button>
+        <button onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/graphs/contributors')"><i class="fa fa-list-ul"></i><span>Credits</span></button>
+        <button onclick="utils.openURL('http://charlielee.uk/animator')"><i class="fa fa-tv"></i><span>Website</span></button>
+      </div>
 
     </section>
   </main>

--- a/app/about.html
+++ b/app/about.html
@@ -12,14 +12,15 @@
 
 <body>
   <main>
-    <div class="content">
+    <section class="content">
       <h1>Boats Animator</h1>
       <h2 id="app-version">Version</h2>
       <p>Boats Animator is a free cross-platform stop motion animation program created using HTML5, JavaScript, and WebRTC. Want to help out? <a href="#" onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/issues')">Report any issues</a> you come across or <a href="#" onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/blob/master/CONTRIBUTING.md')">contribute code</a>!</p>
       <button onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/blob/master/LICENSE')"><i class="fa fa-legal"></i><span>License</span></button>
       <button onclick="utils.openURL('https://github.com/BoatsAreRockable/animator/graphs/contributors')"><i class="fa fa-list-ul"></i><span>Credits</span></button>
       <button onclick="utils.openURL('http://charlielee.uk/animator')"><i class="fa fa-tv"></i><span>Website</span></button>
-    </div>
+
+    </section>
   </main>
 
   <footer>

--- a/app/animator.html
+++ b/app/animator.html
@@ -83,17 +83,19 @@
                 </table>
             </div>
 
-            <table id="control-panel-table">
-                <tr>
-                    <td id="preview-options-td">
-                        <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
-                    </td>
+        <article id="control-panel">
+          <section id="preview-options">
+            <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
+          </section>
 
-                    <td id="onion-opacity-td"><input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2"><div id="slider-background-middle"></div>
-                    </td>
-                    <td id="framerate-container-td"><div id="framerate-container"><input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label></div></td>
-                </tr>
-            </table>
+          <section id="onion-skin-opacity-options">
+            <input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2"><div id="slider-background-middle"></div>
+          </section>
+
+          <section id="frame-rate-options">
+            <input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label>
+          </section>
+        </article>
       </section>
 
         <!--Sidebar content-->

--- a/app/animator.html
+++ b/app/animator.html
@@ -83,7 +83,7 @@
                 </table>
             </div>
 
-        <article id="control-panel">
+        <article id="control-panel" class="flex">
           <section id="preview-options">
             <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
           </section>

--- a/app/animator.html
+++ b/app/animator.html
@@ -44,27 +44,25 @@
       </div>
 
       <!--Playback controls-->
-      <table id="framemod-table">
-        <tr>
-          <td id="left-controls">
-            <div id="btn-delete-last-frame" title="Undo last frame"><i class="fa fa-undo"></i></div>
-          </td>
-          <td id="capture-control">
-            <div id="btn-capture-frame" title="Capture Frame">
-              <i class="fa fa-camera"></i>
-            </div>
-          </td>
-          <td id="playback-controls">
-            <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
-            <div id="btn-frame-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
-            <div id="btn-frame-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
-            <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
-            <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
-            <div id="btn-frame-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
-            <div id="btn-frame-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
-          </td>
-        </tr>
-      </table>
+      <div id="frame-mod-panel" class="flex">
+        <section id="left-controls">
+          <div id="btn-delete-last-frame" title="Undo last frame"><i class="fa fa-undo"></i></div>
+        </section>
+        <section id="capture-control">
+          <div id="btn-capture-frame" title="Capture Frame">
+            <i class="fa fa-camera"></i>
+          </div>
+        </section>
+        <section id="playback-controls">
+          <div id="btn-frame-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
+          <div id="btn-frame-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
+          <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
+          <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
+          <div id="btn-frame-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
+          <div id="btn-frame-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
+          <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
+        </section>
+      </div>
 
       <!--Frame-reel container-->
       <div id="area-frame-reel">
@@ -84,21 +82,19 @@
         </table>
       </div>
 
-      <article id="control-panel" class="flex">
+      <div id="control-panel" class="flex">
         <section id="preview-options">
           <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
         </section>
-
         <section id="onion-skin-opacity-options">
           <input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2">
           <div
             id="slider-background-middle"></div>
         </section>
-
         <section id="frame-rate-options">
           <input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label>
         </section>
-      </article>
+      </div>
     </section>
 
     <!--Sidebar content-->
@@ -115,7 +111,7 @@
             <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#">Project Options</a></li>
             </ul>
         </div>
-    -->
+      -->
 
       <!--Export Options-->
       <div class="sidebar-item" id="export-header">

--- a/app/animator.html
+++ b/app/animator.html
@@ -27,7 +27,7 @@
     </div>
 
     <main>
-      <section>
+      <section id="main-area">
             <!--Capture Window-->
             <div id="capture-window">
                 <!--The actual onion skinning frame, injected through JS-->

--- a/app/animator.html
+++ b/app/animator.html
@@ -88,8 +88,7 @@
         </section>
         <section id="onion-skin-opacity-options">
           <input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2">
-          <div
-            id="slider-background-middle"></div>
+          <div id="slider-background-middle"></div>
         </section>
         <section id="frame-rate-options">
           <input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label>

--- a/app/animator.html
+++ b/app/animator.html
@@ -66,23 +66,21 @@
                 </table>
 
             <!--Frame-reel container-->
-            <div id="frame-reel-container">
-                <div id="area-frame-reel">
-                    <p>No frames captured</p>
-                    <table class="hidden">
-                        <tr id="reel-captured-imgs">
-                        <!--This is where the frame is added through JS -->
-                        </tr>
-                        <tr>
-                            <td class="frame-reel-preview">
-                            <div class="frame-reel-no" id="live-view-frame-no"></div>
-                            <div id="btn-live-view" title="Live Preview">
-                                <i class="fa fa-video-camera"></i>
-                                </div>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
+            <div id="area-frame-reel">
+                <p>No frames captured</p>
+                <table class="hidden">
+                    <tr id="reel-captured-imgs">
+                    <!--This is where the frame is added through JS -->
+                    </tr>
+                    <tr>
+                        <td class="frame-reel-preview">
+                        <div class="frame-reel-no" id="live-view-frame-no"></div>
+                        <div id="btn-live-view" title="Live Preview">
+                            <i class="fa fa-video-camera"></i>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
             </div>
 
             <table id="control-panel-table">

--- a/app/animator.html
+++ b/app/animator.html
@@ -27,109 +27,111 @@
     </div>
 
     <main>
-        <!--Capture Window-->
-        <div id="capture-window">
-            <!--The actual onion skinning frame, injected through JS-->
-            <img id="onion-skinning-frame">
-            <!-- Video preview stream -->
-            <video id="preview" autoplay>Video stream not available.</video>
-        </div>
+      <section>
+            <!--Capture Window-->
+            <div id="capture-window">
+                <!--The actual onion skinning frame, injected through JS-->
+                <img id="onion-skinning-frame">
+                <!-- Video preview stream -->
+                <video id="preview" autoplay>Video stream not available.</video>
+            </div>
 
-        <!--Playback Window-->
-        <div id="playback-window" class="hidden">
-            <!--The actual playback window -->
-            <canvas id="playback"></canvas>
-        </div>
+            <!--Playback Window-->
+            <div id="playback-window" class="hidden">
+                <!--The actual playback window -->
+                <canvas id="playback"></canvas>
+            </div>
 
-        <!--Playback controls-->
-            <table id="framemod-table">
-                <tr>
-                    <td id="left-controls">
-                        <div id="btn-delete-last-frame" title="Undo last frame"><i class="fa fa-undo"></i></div>
-                    </td>
-                    <td id="capture-control">
-                        <div id="btn-capture-frame" title="Capture Frame">
-                            <i class="fa fa-camera"></i>
-                        </div>
-                    </td>
-                    <td id="playback-controls">
-                      <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
-                      <div id="btn-frame-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
-                      <div id="btn-frame-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
-                      <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
-                      <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
-                      <div id="btn-frame-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
-                      <div id="btn-frame-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
-                    </td>
-                </tr>
-            </table>
-
-        <!--Frame-reel container-->
-        <div id="frame-reel-container">
-            <div id="area-frame-reel">
-                <p>No frames captured</p>
-                <table class="hidden">
-                    <tr id="reel-captured-imgs">
-                      <!--This is where the frame is added through JS -->
-                    </tr>
+            <!--Playback controls-->
+                <table id="framemod-table">
                     <tr>
-                        <td class="frame-reel-preview">
-                          <div class="frame-reel-no" id="live-view-frame-no"></div>
-                           <div id="btn-live-view" title="Live Preview">
-                             <i class="fa fa-video-camera"></i>
+                        <td id="left-controls">
+                            <div id="btn-delete-last-frame" title="Undo last frame"><i class="fa fa-undo"></i></div>
+                        </td>
+                        <td id="capture-control">
+                            <div id="btn-capture-frame" title="Capture Frame">
+                                <i class="fa fa-camera"></i>
                             </div>
+                        </td>
+                        <td id="playback-controls">
+                        <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
+                        <div id="btn-frame-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
+                        <div id="btn-frame-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
+                        <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
+                        <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
+                        <div id="btn-frame-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
+                        <div id="btn-frame-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
                         </td>
                     </tr>
                 </table>
+
+            <!--Frame-reel container-->
+            <div id="frame-reel-container">
+                <div id="area-frame-reel">
+                    <p>No frames captured</p>
+                    <table class="hidden">
+                        <tr id="reel-captured-imgs">
+                        <!--This is where the frame is added through JS -->
+                        </tr>
+                        <tr>
+                            <td class="frame-reel-preview">
+                            <div class="frame-reel-no" id="live-view-frame-no"></div>
+                            <div id="btn-live-view" title="Live Preview">
+                                <i class="fa fa-video-camera"></i>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
             </div>
+
+            <table id="control-panel-table">
+                <tr>
+                    <td id="preview-options-td">
+                        <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
+                    </td>
+
+                    <td id="onion-opacity-td"><input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2"><div id="slider-background-middle"></div>
+                    </td>
+                    <td id="framerate-container-td"><div id="framerate-container"><input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label></div></td>
+                </tr>
+            </table>
+      </section>
+
+        <!--Sidebar content-->
+      <aside>
+            <!--Project Options, currently disabled because there is no code yet-->
+    <!--
+        <div class="sidebar-item" id="debugging-header">
+            <div class="sidebar-header">
+            <h2><i class="fa fa-file-text fa-fw"></i> Project</h2>
+            </div>
+            <ul>
+            <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#">New Project</a></li>
+            <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#">Open Project</a></li>
+            <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#">Project Options</a></li>
+            </ul>
         </div>
+    -->
 
-        <table id="control-panel-table">
-            <tr>
-                <td id="preview-options-td">
-                    <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
-                </td>
-
-                <td id="onion-opacity-td"><input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2"><div id="slider-background-middle"></div>
-                </td>
-                <td id="framerate-container-td"><div id="framerate-container"><input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label></div></td>
-            </tr>
-        </table>
+        <!--Export Options-->
+        <div class="sidebar-item" id="export-header">
+            <div class="sidebar-header">
+            <h2><i class="fa fa-download fa-fw"></i> Export</h2>
+            </div>
+            <ul>
+            <li>Captured frames will be exported to:
+                <p id="currentDirectoryName" class="italics">No directory selected</p>
+            </li>
+            <li>
+                <i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i>
+                <span class="sidebar-opt" id="btn-dir-change">Change directory</span>
+                <input id="chooseDirectory" style="display:none;" type="file" nwdirectory  />
+            </li>
+            </ul>
+        </div>
+      </aside>
     </main>
-
-    <!--Sidebar content-->
-    <aside>
-        <!--Project Options, currently disabled because there is no code yet-->
-<!--
-      <div class="sidebar-item" id="debugging-header">
-        <div class="sidebar-header">
-          <h2><i class="fa fa-file-text fa-fw"></i> Project</h2>
-        </div>
-        <ul>
-          <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#">New Project</a></li>
-          <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#">Open Project</a></li>
-          <li><i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i><a href="#">Project Options</a></li>
-        </ul>
-      </div>
--->
-
-      <!--Export Options-->
-      <div class="sidebar-item" id="export-header">
-        <div class="sidebar-header">
-          <h2><i class="fa fa-download fa-fw"></i> Export</h2>
-        </div>
-        <ul>
-          <li>Captured frames will be exported to:
-            <p id="currentDirectoryName" class="italics">No directory selected</p>
-          </li>
-          <li>
-            <i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i>
-            <span class="sidebar-opt" id="btn-dir-change">Change directory</span>
-            <input id="chooseDirectory" style="display:none;" type="file" nwdirectory  />
-          </li>
-        </ul>
-      </div>
-    </aside>
 
     <footer>
         <ul>

--- a/app/animator.html
+++ b/app/animator.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2">
@@ -14,94 +15,96 @@
   <!-- Notification Bar -->
   <section id="notification-container"></section>
 
-    <!--Confirm messages-->
-    <div id="confirm-container" class="hidden">
-        <section id="confirm">
-            <h2 id="confirm-title"><i class="fa fa-exclamation-triangle"></i> Confirm</h2>
-            <p id="confirm-text"></p>
-            <div id="confirm-button-container">
-                <button id="btn-cancel">Cancel</button>
-                <button id="btn-OK">OK</button>
+  <!--Confirm messages-->
+  <div id="confirm-container" class="hidden">
+    <section id="confirm">
+      <h2 id="confirm-title"><i class="fa fa-exclamation-triangle"></i> Confirm</h2>
+      <p id="confirm-text"></p>
+      <div id="confirm-button-container">
+        <button id="btn-cancel">Cancel</button>
+        <button id="btn-OK">OK</button>
+      </div>
+    </section>
+  </div>
+
+  <main>
+    <section id="main-area">
+      <!--Capture Window-->
+      <div id="capture-window">
+        <!--The actual onion skinning frame, injected through JS-->
+        <img id="onion-skinning-frame">
+        <!-- Video preview stream -->
+        <video id="preview" autoplay>Video stream not available.</video>
+      </div>
+
+      <!--Playback Window-->
+      <div id="playback-window" class="hidden">
+        <!--The actual playback window -->
+        <canvas id="playback"></canvas>
+      </div>
+
+      <!--Playback controls-->
+      <table id="framemod-table">
+        <tr>
+          <td id="left-controls">
+            <div id="btn-delete-last-frame" title="Undo last frame"><i class="fa fa-undo"></i></div>
+          </td>
+          <td id="capture-control">
+            <div id="btn-capture-frame" title="Capture Frame">
+              <i class="fa fa-camera"></i>
             </div>
+          </td>
+          <td id="playback-controls">
+            <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
+            <div id="btn-frame-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
+            <div id="btn-frame-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
+            <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
+            <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
+            <div id="btn-frame-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
+            <div id="btn-frame-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
+          </td>
+        </tr>
+      </table>
+
+      <!--Frame-reel container-->
+      <div id="area-frame-reel">
+        <p>No frames captured</p>
+        <table class="hidden">
+          <tr id="reel-captured-imgs">
+            <!--This is where the frame is added through JS -->
+          </tr>
+          <tr>
+            <td class="frame-reel-preview">
+              <div class="frame-reel-no" id="live-view-frame-no"></div>
+              <div id="btn-live-view" title="Live Preview">
+                <i class="fa fa-video-camera"></i>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
+
+      <article id="control-panel" class="flex">
+        <section id="preview-options">
+          <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
         </section>
-    </div>
 
-    <main>
-      <section id="main-area">
-            <!--Capture Window-->
-            <div id="capture-window">
-                <!--The actual onion skinning frame, injected through JS-->
-                <img id="onion-skinning-frame">
-                <!-- Video preview stream -->
-                <video id="preview" autoplay>Video stream not available.</video>
-            </div>
+        <section id="onion-skin-opacity-options">
+          <input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2">
+          <div
+            id="slider-background-middle"></div>
+        </section>
 
-            <!--Playback Window-->
-            <div id="playback-window" class="hidden">
-                <!--The actual playback window -->
-                <canvas id="playback"></canvas>
-            </div>
+        <section id="frame-rate-options">
+          <input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label>
+        </section>
+      </article>
+    </section>
 
-            <!--Playback controls-->
-                <table id="framemod-table">
-                    <tr>
-                        <td id="left-controls">
-                            <div id="btn-delete-last-frame" title="Undo last frame"><i class="fa fa-undo"></i></div>
-                        </td>
-                        <td id="capture-control">
-                            <div id="btn-capture-frame" title="Capture Frame">
-                                <i class="fa fa-camera"></i>
-                            </div>
-                        </td>
-                        <td id="playback-controls">
-                        <div id="btn-loop" title="Loop Playback"><i class="fa fa-refresh"></i></div>
-                        <div id="btn-frame-last" title="Last frame"><i class="fa fa-fast-forward"></i></div>
-                        <div id="btn-frame-next" title="Next frame"><i class="fa fa-step-forward"></i></div>
-                        <div id="btn-stop" title="Stop Playback"><i class="fa fa-stop"></i></div>
-                        <div id="btn-play-pause" title="Playback Frames"><i class="fa fa-play"></i></div>
-                        <div id="btn-frame-previous" title="Previous frame"><i class="fa fa-step-backward"></i></div>
-                        <div id="btn-frame-first" title="First frame"><i class="fa fa-fast-backward"></i></div>
-                        </td>
-                    </tr>
-                </table>
-
-            <!--Frame-reel container-->
-            <div id="area-frame-reel">
-                <p>No frames captured</p>
-                <table class="hidden">
-                    <tr id="reel-captured-imgs">
-                    <!--This is where the frame is added through JS -->
-                    </tr>
-                    <tr>
-                        <td class="frame-reel-preview">
-                        <div class="frame-reel-no" id="live-view-frame-no"></div>
-                        <div id="btn-live-view" title="Live Preview">
-                            <i class="fa fa-video-camera"></i>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-
-        <article id="control-panel" class="flex">
-          <section id="preview-options">
-            <div id="btn-grid-toggle"><i class="fa fa-th" title="Grid Overlay"></i></div>
-          </section>
-
-          <section id="onion-skin-opacity-options">
-            <input id="input-onion-skin-opacity" type="range" name="onionSkinAmount" min="-100" max="100" value="0" title="0%" step="2"><div id="slider-background-middle"></div>
-          </section>
-
-          <section id="frame-rate-options">
-            <input id="input-fr-change" type="number" value="15" min="1" max="60" title="Framerate"><label for="input-fr-change"> FPS</label>
-          </section>
-        </article>
-      </section>
-
-        <!--Sidebar content-->
-      <aside>
-            <!--Project Options, currently disabled because there is no code yet-->
-    <!--
+    <!--Sidebar content-->
+    <aside>
+      <!--Project Options, currently disabled because there is no code yet-->
+      <!--
         <div class="sidebar-item" id="debugging-header">
             <div class="sidebar-header">
             <h2><i class="fa fa-file-text fa-fw"></i> Project</h2>
@@ -114,35 +117,36 @@
         </div>
     -->
 
-        <!--Export Options-->
-        <div class="sidebar-item" id="export-header">
-            <div class="sidebar-header">
-            <h2><i class="fa fa-download fa-fw"></i> Export</h2>
-            </div>
-            <ul>
-            <li>Captured frames will be exported to:
-                <p id="currentDirectoryName" class="italics">No directory selected</p>
-            </li>
-            <li>
-                <i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i>
-                <span class="sidebar-opt" id="btn-dir-change">Change directory</span>
-                <input id="chooseDirectory" style="display:none;" type="file" nwdirectory  />
-            </li>
-            </ul>
+      <!--Export Options-->
+      <div class="sidebar-item" id="export-header">
+        <div class="sidebar-header">
+          <h2><i class="fa fa-download fa-fw"></i> Export</h2>
         </div>
-      </aside>
-    </main>
-
-    <footer>
         <ul>
-            <li>Frame <span id="current-frame">0</span> of <span id="num-of-frames">0</span></li>
-            <li id="current-frame-rate"><span></span> FPS</li>
-            <li class="no-pipe" id="current-mode"><span></span> mode</li>
+          <li>Captured frames will be exported to:
+            <p id="currentDirectoryName" class="italics">No directory selected</p>
+          </li>
+          <li>
+            <i class="fa fa-sort-asc fa-rotate-90 sidebar-link-dot"></i>
+            <span class="sidebar-opt" id="btn-dir-change">Change directory</span>
+            <input id="chooseDirectory" style="display:none;" type="file" nwdirectory />
+          </li>
         </ul>
-    </footer>
+      </div>
+    </aside>
+  </main>
+
+  <footer>
+    <ul>
+      <li>Frame <span id="current-frame">0</span> of <span id="num-of-frames">0</span></li>
+      <li id="current-frame-rate"><span></span> FPS</li>
+      <li class="no-pipe" id="current-mode"><span></span> mode</li>
+    </ul>
+  </footer>
 
   <script id="dev-reload-script"></script>
   <script src="js/utils.js"></script>
   <script src="js/main.js"></script>
 </body>
+
 </html>

--- a/app/css/about.css
+++ b/app/css/about.css
@@ -1,19 +1,4 @@
-/* ======= Buttons ======== */
+/* Buttons
+   -------------------------------- */
 
-.content button {
-    width: calc(33% - 0.5em);
-    margin-right: 0.5em;
-    float: left;
-}
-
-.content button:last-of-type { margin: 0; }
-
-.content button i {
-    font-size: 400%;
-    float: left;
-}
-
-.content button span {
-    display: block;
-    transform: translateY(100%);
-}
+.content button i { font-size: 4em; }

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -61,29 +61,29 @@
 /* ========== CONFIRM BOXES ========== */
 
 #confirm-container {
-    position: absolute;
-    height: 100vh;
-    width: 100vw;
-    background-color: rgba(23, 23, 23, 0.5);
-    z-index: 4;
-    text-align: center;
+  position: absolute;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(23, 23, 23, 0.5);
+  z-index: 4;
+  text-align: center;
 }
 
 #confirm-container.hidden { display: none; }
 
 #confirm {
-    position: relative;
-    top: calc(50vh - 10em);
-    display: inline-block;
-    width: 20em;
-    background-color: #000;
-    padding: 0 1em 1em 1em;
-    border: 1px solid #D9D9D9;
+  position: relative;
+  top: calc(50vh - 10em);
+  display: inline-block;
+  width: 20em;
+  background-color: #000;
+  padding: 0 1em 1em 1em;
+  border: 1px solid #D9D9D9;
 }
 
 #confirm-title {
-    font-size: 1.2em;
-    color: rgb(224, 224, 100);
+  font-size: 1.2em;
+  color: rgb(224, 224, 100);
 }
 
 #confirm-text { text-align: left; }
@@ -91,9 +91,9 @@
 #confirm-button-container { float: right; }
 
 #confirm button {
-    float: left;
-    margin-left: 1em;
-    width: 6em;
+  float: left;
+  margin-left: 1em;
+  width: 6em;
 }
 
 #confirm button:hover { opacity: 0.9; }

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -210,17 +210,11 @@
 
 /* ========== FRAME REEL ============== */
 
-#frame-reel-container {
-  position: relative;
-}
-
 /* Frame reel area */
 #area-frame-reel {
-  position: relative;
-  top: -3px;
-  overflow-x: scroll;
   background-color: #171717;
   height: 6.2em;
+  overflow-x: scroll;
 }
 
 #area-frame-reel table {
@@ -283,9 +277,10 @@ td:first-of-type .frame-reel-preview {
 /* ========== CONTROL PANEL ============== */
 
 #control-panel-table {
-    white-space: nowrap;
-/*    border: 2px solid red;*/
-    width: 100%;
+  border-spacing: 0;
+  padding: 0.5em 0;
+  white-space: nowrap;
+  width: 100%;
 }
 
 #control-panel-table td {

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -1,3 +1,11 @@
+/* 1. Main area
+   -------------------------------- */
+
+#main-area {
+  display: flex;
+  flex-direction: column;
+}
+
 /* ========== Notification bar ============== */
 
 #notification-container {
@@ -106,8 +114,8 @@
 /* ========== VIDEO PREVIEW ============== */
 
 #capture-window, #playback-window {
-  height: calc(100vh - 210px);
-  width: 100%;
+  display: flex;
+  flex: 1;
   text-align: center;
   background-color: black;
   position: relative;
@@ -119,39 +127,24 @@
 
 #capture-window.active { border-color: #ad0000; }
 
-#preview {
-  position: absolute;
-  top: 0;
-  left: 0;
-  padding: 0;
-  margin: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
+#preview,
 #playback {
-  height: 100%;
-  width: 100%;
-  max-height: calc(100vh - 210px);
+  flex: 1;
   object-fit: contain;
+  width: 100%;
 }
 
 /*========== ONION SKINNING ==============*/
 
 #onion-skinning-frame {
   height: 100%;
-  width: 100%;
-  padding: 0;
-  margin: 0;
-  border: 0;
+  left: 0;
+  object-fit: contain;
   opacity: 0;
   position: absolute;
   top: 0;
-  left: 0;
-  object-fit: contain;
+  width: 100%;
   z-index: 2;
-  display: inline;
 }
 
 #onion-skinning-frame:not([src]){ display:none; }

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -149,64 +149,54 @@
 
 #onion-skinning-frame:not([src]){ display:none; }
 
-/* ========== CONTROLS ============== */
+/* Frame mod panel.
+   -------------------------------- */
 
-#framemod-table {
-  width: 100%;
-  padding-left: 1em;
-  padding-right: 1em;
+#frame-mod-panel {
   background-color: #171717;
+  padding: 0 1em;
+  width: 100%;
 }
 
-#framemod-table div {
+#frame-mod-panel > * {
+  align-items: center;
+  display: flex;
+}
+
+/* Buttons within the frame mod panel */
+#frame-mod-panel div {
   cursor: pointer;
-  font-size: 1.1em;
+  font-size: 1.3em;
   display: inline-block;
+  padding: 0 0.5em;
 }
 
-#left-controls {
-  width: 45%;
-}
+/* ===  Left controls === */
 
-#left-controls i {
-  padding: 0 0.25em;
-  font-size: 1.2em;
-}
+#left-controls { flex: 4; }
 
-#capture-control {
-  text-align: center;
-}
+/* ===  Capture control === */
 
-#playback-controls {
-  width: 45%;
-  font-size: 1.2em;
-}
-
-#btn-capture-frame {
-  cursor: pointer;
-}
+#capture-control { justify-content: center; }
 
 #btn-capture-frame i {
   color: #f9ff23;
-  font-size: 2em;
+  font-size: 1.8em;
   padding: 0.2em 0;
 }
 
-#btn-capture-frame i:hover {
-  color: #f3f76e;
+#btn-capture-frame i:hover { color: #f3f76e; }
+
+/* ===  Playback controls === */
+
+#playback-controls {
+  justify-content: flex-end;
+  flex: 4;
 }
 
-#playback-controls div {
-  padding: 0 0.5em;
-  float: right;
-}
-#btn-play-pause {
-  width: 1.5em;
-}
+#btn-play-pause { width: 1.5em; }
 
-#btn-loop i.active, #btn-onion-skin-toggle i.active {
-  color: #ad0000;
-}
+#btn-loop i.active { color: #ad0000; }
 
 /* ========== FRAME REEL ============== */
 

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -1,4 +1,4 @@
-/* 1. Main area
+/* Main area
    -------------------------------- */
 
 #main-area {
@@ -274,45 +274,19 @@ td:first-of-type .frame-reel-preview {
 #btn-live-view i { padding-top: 0.2em; }
 
 
-/* ========== CONTROL PANEL ============== */
+/* Control panel
+   -------------------------------- */
 
-#control-panel-table {
-  border-spacing: 0;
+#control-panel {
+  display: flex;
   padding: 0.5em 0;
   white-space: nowrap;
   width: 100%;
 }
 
-#control-panel-table td {
-/*    border: 1px solid white;*/
-}
+/* Preview options */
 
-#other-options-container {
-  padding: 1em 0;
-}
-
-#onion-skin-control {
-  display: inline-block;
-  float: left;
-}
-
-#preview-options-td, #framerate-container-td {
-  width: 35%;
-}
-
-#btn-onion-skin-toggle {
-  position: relative;
-/*
-  top: 0.5em;
-  margin-top: 3em;
-*/
-  display: inline-block;
-  cursor: pointer;
-  padding: 0 1em;
-/*  float: right;*/
-}
-
-#btn-onion-skin-toggle i, #btn-grid-toggle i {
+#btn-grid-toggle i {
   font-size: 1.7em;
 }
 
@@ -323,28 +297,10 @@ td:first-of-type .frame-reel-preview {
   padding: 0 1em;
 }
 
-#framerate-container {
-  position: relative;
-  display: inline-block;
-  float: right;
-  padding-right: 1em;
-}
+/* Onion skin opacity options */
 
-#input-fr-change {
-  width: 4em;
-  border: 1px solid #171717;
-  background-color: #d9d9d9;
-  color: #171717;
-  padding: 5px;
-}
-
-#onion-opacity-td {
+#onion-skin-opacity-options {
   text-align: center;
-}
-
-#onion-opacity-slider-container {
-    text-align: center;
-    margin-top: -4.6em;
 }
 
 #slider-background-middle {
@@ -364,7 +320,6 @@ td:first-of-type .frame-reel-preview {
   width: 15em;
 }
 
-
 #input-onion-skin-opacity:focus { outline: none; }
 
 #input-onion-skin-opacity::-webkit-slider-runnable-track {
@@ -383,6 +338,23 @@ td:first-of-type .frame-reel-preview {
 
 #input-onion-skin-opacity:focus::-webkit-slider-runnable-track { background-color: #D9D9D9; }
 
-/* ========== STATUS BAR ============== */
+/* Frame rate options */
+
+#frame-rate-options {
+  display: inline-block;
+  padding-right: 1em;
+  text-align: right;
+}
+
+#input-fr-change {
+  width: 4em;
+  border: 1px solid #171717;
+  background-color: #d9d9d9;
+  color: #171717;
+  padding: 5px;
+}
+
+/* Status bar
+   -------------------------------- */
 
 #current-mode span { text-transform: capitalize; }

--- a/app/css/animator.css
+++ b/app/css/animator.css
@@ -284,11 +284,7 @@ td:first-of-type .frame-reel-preview {
   width: 100%;
 }
 
-/* Preview options */
-
-#btn-grid-toggle i {
-  font-size: 1.7em;
-}
+/* === Preview options === */
 
 #btn-grid-toggle {
   position: relative;
@@ -297,27 +293,24 @@ td:first-of-type .frame-reel-preview {
   padding: 0 1em;
 }
 
-/* Onion skin opacity options */
+#btn-grid-toggle i { font-size: 1.7em; }
 
-#onion-skin-opacity-options {
-  text-align: center;
-}
+/* === Onion skin opacity options === */
+
+#onion-skin-opacity-options { text-align: center; }
 
 #slider-background-middle {
   position: relative;
-/*  left: 1.65em;*/
   height: 1.9em;
   width: 0.09em;
   background-color: white;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: -1.24em;
+  margin: -1.24em auto 0 auto;
   z-index: -1;
 }
 
 #input-onion-skin-opacity {
-  -webkit-appearance: none;
   width: 15em;
+  -webkit-appearance: none;
 }
 
 #input-onion-skin-opacity:focus { outline: none; }
@@ -327,6 +320,7 @@ td:first-of-type .frame-reel-preview {
   cursor: pointer;
   background-color: #D9D9D9;
 }
+
 #input-onion-skin-opacity::-webkit-slider-thumb {
   height: 1.7em;
   width: 1.7em;
@@ -338,7 +332,7 @@ td:first-of-type .frame-reel-preview {
 
 #input-onion-skin-opacity:focus::-webkit-slider-runnable-track { background-color: #D9D9D9; }
 
-/* Frame rate options */
+/* === Frame rate options === */
 
 #frame-rate-options {
   display: inline-block;

--- a/app/css/common.css
+++ b/app/css/common.css
@@ -63,7 +63,7 @@ main h2 {
   font-size: 1.3em;
 }
 
-section {
+main section {
   flex: 1;
   overflow: hidden;
 }

--- a/app/css/common.css
+++ b/app/css/common.css
@@ -18,13 +18,16 @@
 *, *::before, *::after { box-sizing: border-box; }
 
 body {
+  align-items: stretch;
   background-color: #2B2B2B;
   color: #D9D9D9;
   cursor: default;
   display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
   font-family: "Roboto", sans-serif;
   font-size: 0.9em;
-  height: 100%;
+  height: 100vh;
   margin: 0;
   padding: 0;
   -webkit-user-select: none;
@@ -47,28 +50,29 @@ a:active { text-decoration: none; }
    -------------------------------- */
 
 main {
+  display: flex;
+  flex: 1;
+}
+
+main h1 {
+  font-size: 1.8em;
+  margin: 0.5em 0;
+}
+
+main h2 {
+  font-size: 1.3em;
+}
+
+section {
   flex: 1;
   overflow: hidden;
 }
 
 .content {
   background-color: #171717;
-  height: 100vh;
   margin: 0;
-  overflow: hidden;
   padding: 0 1em;
   width: 100%;
-}
-
-.content h1 {
-  margin: 0;
-  padding: 0.5em 0 0 0;
-}
-
-.content h2 {
-  font-size: 1.2em;
-  margin: 0;
-  padding: 0.83em 0;
 }
 
 .content p {
@@ -104,8 +108,6 @@ aside label {
   vertical-align: middle;
 }
 
-aside h2 { font-size: 1.2em; }
-
 aside ul {
   line-height: 1.4;
   list-style: none;
@@ -128,12 +130,9 @@ aside li { margin-left: -0.7em; }
 
 footer {
   background-color: #d9d9d9;
-  bottom: 0;
   color: #2B2B2B;
-  left: 0;
-  position: fixed;
+  flex: initial;
   width: 100%;
-  z-index: 2;
 }
 
 footer a { color: #2B2B2B; }

--- a/app/css/common.css
+++ b/app/css/common.css
@@ -65,7 +65,6 @@ main h2 {
 
 main section {
   flex: 1;
-  overflow: hidden;
 }
 
 .content {

--- a/app/css/common.css
+++ b/app/css/common.css
@@ -35,6 +35,20 @@ body {
 
 img { -webkit-user-drag: none; }
 
+/* Container for a row of buttons */
+
+.btn-group { display: flex; }
+
+.btn-group button {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  margin-right: 1em;
+}
+.btn-group button:last-of-type { margin-right: 0; }
+
+.btn-group span { flex: 1; }
+
 /* 2. Links
    -------------------------------- */
 

--- a/app/css/common.css
+++ b/app/css/common.css
@@ -36,9 +36,7 @@ body {
 img { -webkit-user-drag: none; }
 
 /* Container for a row of buttons */
-
 .btn-group { display: flex; }
-
 .btn-group button {
   align-items: center;
   display: flex;
@@ -46,8 +44,11 @@ img { -webkit-user-drag: none; }
   margin-right: 1em;
 }
 .btn-group button:last-of-type { margin-right: 0; }
-
 .btn-group span { flex: 1; }
+
+/* Denotes an element as a flexbox and sets its children to "flex: 1" */
+.flex { display: flex; }
+.flex > * { flex: 1; }
 
 /* 2. Links
    -------------------------------- */
@@ -68,6 +69,11 @@ main {
   flex: 1;
 }
 
+main > section {
+  flex: 1;
+  overflow: hidden;
+}
+
 main h1 {
   font-size: 1.8em;
   margin: 0.5em 0;
@@ -75,10 +81,6 @@ main h1 {
 
 main h2 {
   font-size: 1.3em;
-}
-
-main section {
-  flex: 1;
 }
 
 .content {

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -1,17 +1,17 @@
 /* ========== Projects Area ============= */
 
 #projects-container {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 #projects-container li {
-    margin: 0;
-    width: 100%;
-    padding: 1em 0;
-    list-style-type: none;
-    border-bottom: 1px solid #ADADAD;
-    position: relative;
+  margin: 0;
+  width: 100%;
+  padding: 1em 0;
+  list-style-type: none;
+  border-bottom: 1px solid #ADADAD;
+  position: relative;
 }
 
 #projects-container li:first-of-type { padding-top: 0; }
@@ -51,21 +51,21 @@
 
 
 .container-news {
-    margin-top: -0.8em;
-    height: 25.8em;
-    overflow-y: scroll;
+  margin-top: -0.8em;
+  height: 25.8em;
+  overflow-y: scroll;
 }
 
 .post,
 .container-news h3  {
-    color: #fff;
-    padding-right: 1em;
+  color: #fff;
+  padding-right: 1em;
 }
 .post { margin-bottom: 1.5em; }
 
 .post-link {
-    color: #fff;
-    text-decoration: none;
+  color: #fff;
+  text-decoration: none;
 }
 .post-link:hover {
   color: #fff;
@@ -73,11 +73,11 @@
 }
 
 .post-title {
-    margin: 0;
-    margin-bottom: -0.4em;
-    font-size: 1.2em;
-    font-weight: 500;
-    color: #fff;
+  margin: 0;
+  margin-bottom: -0.4em;
+  font-size: 1.2em;
+  font-weight: 500;
+  color: #fff;
 }
 .post-date {
   margin: 0.2em 0 1.2em 0;

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -20,22 +20,7 @@
 #projects-container a { color: #d3d3d3; }
 #projects-container a:hover { border-bottom: 1.5px solid #d3d3d3; }
 
-.content button {
-    width: calc(50% - 0.5em);
-    float: left;
-}
-
-.content button:last-of-type { float: right; }
-
-.content button i {
-    font-size: 400%;
-    float: left;
-}
-
-.content button span {
-    display: block;
-    transform: translateY(100%);
-}
+.content button i { font-size: 4em; }
 
 /* ========== Recent News ============ */
 .loading-dots {

--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
@@ -43,7 +44,7 @@
           <li>
             <div class="container-news">
               <div class="loading-dots">
-              <span class="dot one">.</span><span class="dot two">.</span><span class="dot three">.</span>
+                <span class="dot one">.</span><span class="dot two">.</span><span class="dot three">.</span>
               </div>
             </div>
           </li>
@@ -53,7 +54,7 @@
   </main>
 
   <footer>
-    <ul> 
+    <ul>
       <li class="no-pipe">Version <span id="app-version"></span></li>
     </ul>
   </footer>
@@ -62,4 +63,5 @@
   <script src="js/utils.js"></script>
   <script src="js/index.js"></script>
 </body>
+
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -21,14 +21,15 @@
         <li><i class="fa fa-folder-open-o"></i> <a href="#">Recent Project 2</a></li>
         <li><i class="fa fa-folder-open-o"></i> <a href="#">Recent Project 3</a></li>
       </ul>-->
+      <div class="btn-group">
+        <button id="new-project">
+          <i class="fa fa-file-o"></i><span>New Project</span>
+        </button>
 
-      <button id="new-project">
-        <i class="fa fa-file-o"></i><span>New Project</span>
-      </button>
-
-      <button id="load-project" onclick="alert('This feature is not yet available!')">
-        <i class="fa fa-folder-o"></i><span>Load Project</span>
-      </button>
+        <button id="load-project" onclick="alert('This feature is not yet available!')">
+          <i class="fa fa-folder-o"></i><span>Load Project</span>
+        </button>
+      </div>
     </section>
 
     <!-- News feed -->

--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,7 @@
 <body>
 
   <main>
-    <div class="content">
+    <section class="content">
       <h2>Projects</h2>
       <!--Recent projects example, disabled as will be dynamically injected.
       <ul id="projects-container">
@@ -29,27 +29,27 @@
       <button id="load-project" onclick="alert('This feature is not yet available!')">
         <i class="fa fa-folder-o"></i><span>Load Project</span>
       </button>
-    </div>
-  </main>
+    </section>
 
-  <!-- News feed -->
-  <aside>
-    <div class="sidebar-item">
-      <div class="sidebar-header">
-        <h2><i class="fa fa-newspaper-o"></i>Recent News</h2>
-      </div>
+    <!-- News feed -->
+    <aside>
+      <div class="sidebar-item">
+        <div class="sidebar-header">
+          <h2><i class="fa fa-newspaper-o"></i>Recent News</h2>
+        </div>
 
-      <ul>
-        <li>
-          <div class="container-news">
-            <div class="loading-dots">
-            <span class="dot one">.</span><span class="dot two">.</span><span class="dot three">.</span>
+        <ul>
+          <li>
+            <div class="container-news">
+              <div class="loading-dots">
+              <span class="dot one">.</span><span class="dot two">.</span><span class="dot three">.</span>
+              </div>
             </div>
-          </div>
-        </li>
-      </ul>
-    </div>
-  </aside>
+          </li>
+        </ul>
+      </div>
+    </aside>
+  </main>
 
   <footer>
     <ul> 


### PR DESCRIPTION
In this PR:
* Tables used for design purposes have been replaced by Flexboxes where possible.
* Unnecessary CSS has been removed
* Move more duplicated CSS to `common.css`
* Increased usage of HTML5 Semantic elements
* `animator.html` is now fully indented with 2 spaces.